### PR TITLE
Remove the fixed version numbers of dependencies

### DIFF
--- a/ios/facebook_sdk.podspec
+++ b/ios/facebook_sdk.podspec
@@ -15,8 +15,8 @@ A new flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '5.0.0'
-  s.dependency 'FBSDKLoginKit', '5.0.0'
+  s.dependency 'FBSDKCoreKit'
+  s.dependency 'FBSDKLoginKit'
 
   # https://github.com/flutter/flutter/issues/14161
   s.static_framework = true


### PR DESCRIPTION
 You are using a fixed version of both "FBSDKCoreKit" and "FBSDKLoginKit" and the version you are specifying is using the deprecated AP UIWebView. The deprecated API replaced starting from version 5.5.0 so I have removed the fixed numbers and let the pod find the latest version to install.